### PR TITLE
Display pointers as hexadecimal values in the UI

### DIFF
--- a/src/trace_processor/importers/fuchsia/fuchsia_trace_utils.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_trace_utils.cc
@@ -80,7 +80,7 @@ Variadic ArgValue::ToStorageVariadic(TraceStorage* storage) const {
     case ArgType::kString:
       return Variadic::String(string_);
     case ArgType::kPointer:
-      return Variadic::Integer(static_cast<int64_t>(pointer_));
+      return Variadic::Pointer(static_cast<uint64_t>(pointer_));
     case ArgType::kKoid:
       return Variadic::Integer(static_cast<int64_t>(koid_));
     case ArgType::kUnknown:


### PR DESCRIPTION
Perfetto already had logic for this, the value was just being mistagged
as an integer instead of a pointer.

Signed-off-by: Tudor Brindus <tbrindus@janestreet.com>

![image](https://user-images.githubusercontent.com/1403503/160524187-09bbd4fb-e020-4329-abfc-b1265e7b3946.png)
