### PR TITLE
Remove google analytics

### DIFF
--- a/ui/src/frontend/analytics.ts
+++ b/ui/src/frontend/analytics.ts
@@ -23,6 +23,7 @@ const ANALYTICS_ID = 'UA-137828855-1';
 const PAGE_TITLE = 'no-page-title';
 
 export function initAnalytics() {
+  return new NullAnalytics();
   // Only initialize logging on the official site and on localhost (to catch
   // analytics bugs when testing locally).
   // Skip analytics is the fragment has "testing=1", this is used by UI tests.

--- a/ui/src/frontend/home_page.ts
+++ b/ui/src/frontend/home_page.ts
@@ -14,21 +14,37 @@
 
 import * as m from 'mithril';
 
-import {globals} from './globals';
-import {createPage} from './pages';
+import { globals } from './globals';
+import { createPage } from './pages';
 
 
 export const HomePage = createPage({
   view() {
     return m(
-        '.page.home-page',
-        m(
-            '.home-page-center',
-            m('.home-page-title', 'Perfetto'),
-          m(`img.logo[src=${globals.root}assets/logo-3d.png]`),
-            ),
+      '.page.home-page',
+      m(
+        '.home-page-center',
+        m('.home-page-title', 'Perfetto'),
+        m(`img.logo[src=${globals.root}assets/logo-3d.png]`),
+      ),
+      /*
         m('a.privacy',
           {href: 'https://policies.google.com/privacy', target: '_blank'},
-          'Privacy policy'));
+          'Privacy policy')
+            m(
+                'div.channel-select',
+                m('div',
+                  'Feeling adventurous? Try our bleeding edge Canary version'),
+                m(
+                    'fieldset',
+                    mkChan('stable'),
+                    mkChan('canary'),
+                    m('.highlight'),
+                    ),
+                m(`.home-page-reload${channelChanged() ? '.show' : ''}`,
+                  'You need to reload the page for the changes to have effect'),
+                ),
+      */
+    );
   }
 });


### PR DESCRIPTION
...and remove the privacy policy from the homepage. It's unnecessary now
that there's no more GA.

Tested with a local dev instance.

