### PR TITLE
Disable more Google-specific functionality

### DIFF
--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -129,26 +129,32 @@ function setupContentSecurityPolicy() {
   const policy = {
     'default-src': [
       `'self'`,
+      /*
       // Google Tag Manager bootstrap.
       `'sha256-LirUKeorCU4uRNtNzr8tlB11uy8rzrdmqHCX38JSwHY='`,
+      */
     ],
     'script-src': [
       `'self'`,
       // TODO(b/201596551): this is required for Wasm after crrev.com/c/3179051
       // and should be replaced with 'wasm-unsafe-eval'.
       `'unsafe-eval'`,
+      /*
       'https://*.google.com',
       'https://*.googleusercontent.com',
       'https://www.googletagmanager.com',
       'https://www.google-analytics.com',
+      */
     ],
     'object-src': ['none'],
     'connect-src': [
       `'self'`,
       'http://127.0.0.1:9001',  // For trace_processor_shell --httpd.
       'ws://127.0.0.1:9001',    // Ditto, for the websocket RPC.
+      /*
       'https://www.google-analytics.com',
       'https://*.googleapis.com',  // For Google Cloud Storage fetches.
+      */
       'blob:',
       'data:',
     ],
@@ -156,10 +162,12 @@ function setupContentSecurityPolicy() {
       `'self'`,
       'data:',
       'blob:',
+      /*
       'https://www.google-analytics.com',
       'https://www.googletagmanager.com',
+      */
     ],
-    'navigate-to': ['https://*.perfetto.dev', 'self'],
+    'navigate-to': ['https://*.magic-trace.org', 'self'],
   };
   const meta = document.createElement('meta');
   meta.httpEquiv = 'Content-Security-Policy';
@@ -187,15 +195,20 @@ function main() {
 
   // Load the script to detect if this is a Googler (see comments on globals.ts)
   // and initialize GA after that (or after a timeout if something goes wrong).
-  const script = document.createElement('script');
-  script.src =
+  if (true) {
+    setTimeout(() => globals.logging.initialize(), 5000);
+    document.head.append(css);
+  } else {
+    const script = document.createElement('script');
+    script.src =
       'https://storage.cloud.google.com/perfetto-ui-internal/is_internal_user.js';
-  script.async = true;
-  script.onerror = () => globals.logging.initialize();
-  script.onload = () => globals.logging.initialize();
-  setTimeout(() => globals.logging.initialize(), 5000);
+    script.async = true;
+    script.onerror = () => globals.logging.initialize();
+    script.onload = () => globals.logging.initialize();
+    setTimeout(() => globals.logging.initialize(), 5000);
 
-  document.head.append(script, css);
+    document.head.append(script, css);
+  }
 
   // Add Error handlers for JS error and for uncaught exceptions in promises.
   setErrorHandler((err: string) => maybeShowErrorDialog(err));


### PR DESCRIPTION
- Set up a content-security policy that prohibits google domains.
- Do not detect if the user is Google-internal. All our users are
  external.