### PR TITLE
Make examples come up when users click on them

### DIFF
--- a/ui/src/controller/track_decider.ts
+++ b/ui/src/controller/track_decider.ts
@@ -403,7 +403,7 @@ class TrackDecider {
       summaryTrackId,
       name: MEM_DMA_COUNTER_NAME,
       id,
-      collapsed: true,
+      collapsed: false,
     });
     this.addTrackGroupActions.push(addGroup);
   }
@@ -494,7 +494,7 @@ class TrackDecider {
         summaryTrackId: groupIds.summaryTrackId,
         name: groupName,
         id: groupIds.id,
-        collapsed: true,
+        collapsed: false,
       });
       this.addTrackGroupActions.push(addGroup);
     }
@@ -1134,7 +1134,6 @@ class TrackDecider {
       const threadName = it.threadName;
       const processName = it.processName;
       const hasSched = !!it.hasSched;
-      const hasHeapProfiles = !!it.hasHeapProfiles;
 
       const labels = [];
       if (it.argSetId !== null) {
@@ -1183,7 +1182,7 @@ class TrackDecider {
           // Perf profiling tracks remain collapsed, otherwise we would have too
           // many expanded process tracks for some perf traces, leading to
           // jankyness.
-          collapsed: !hasHeapProfiles,
+          collapsed: false,
         });
 
         this.addTrackGroupActions.push(addTrackGroup);

--- a/ui/src/frontend/sidebar.ts
+++ b/ui/src/frontend/sidebar.ts
@@ -459,6 +459,7 @@ function openTraceUrl(url: string): (e: Event) => void {
     globals.logging.logEvent('Trace Actions', 'Open example trace');
     e.preventDefault();
     globals.dispatch(Actions.openTraceFromUrl({url}));
+    navigateViewer(e);
   };
 }
 
@@ -478,6 +479,7 @@ function onInputElementFileSelectionChanged(e: Event) {
 
   globals.logging.logEvent('Trace Actions', 'Open trace from file');
   globals.dispatch(Actions.openTraceFromFile({file}));
+  navigateViewer(e);
 }
 
 async function openWithLegacyUi(file: File) {


### PR DESCRIPTION
This has two parts:

1. Show the timeline as soon as a trace is loaded.
2. Expand all the tracks as on initial load.

Fixes #16
Fixes #17