### PR TITLE
Updated Perfetto to display longer names appropriately.

### DIFF
--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -63,6 +63,7 @@
   max-height: 30px;
   overflow: hidden;
   text-align: left;
+  white-space: nowrap;
   overflow-wrap: break-word;
   font-family: var(--main-font);
   font-weight: 300;

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -78,6 +78,17 @@ export class TrackGroupPanel extends Panel<Attrs> {
       name = StripPathFromExecutable(name);
     }
 
+    // For strings that end in extra information in brackets, e.g. [pid=555]
+    // this ensures that information is wrapped to the second line for
+    // visibility.
+    const match = (/\[[a-z|()]+=[0-9]+\]/).exec(name);
+    let cmdline = name;
+    let info = '';
+    if (match) {
+      info = name.substring(match.index);
+      cmdline = name.substring(0, match.index);
+    }
+
     // The shell should be highlighted if the current search result is inside
     // this track group.
     let highlightClass = '';
@@ -131,7 +142,9 @@ export class TrackGroupPanel extends Panel<Attrs> {
               this.trackGroupState.collapsed ? EXPAND_DOWN : EXPAND_UP)),
           m('h1.track-title',
             {title: name},
-            name,
+            cmdline,
+            match && m('br'),
+            match && info,
             ('namespace' in this.summaryTrackState.config) &&
                 m('span.chip', 'metric')),
           selection && selection.kind === 'AREA' ?


### PR DESCRIPTION
Magic-trace now displays names as `$cmdline [pid=$pid] [tid=$tid]` (or similar). This PR makes sure that the pid/tid are always visible and will cutoff the command line line if longer than the maximum width. However the entire name is still visible through the tooltip if needed.
