### PR TITLE
Added check for lastValues[0] = 0 to render counter track correctly

### DIFF
--- a/ui/src/tracks/counter/frontend.ts
+++ b/ui/src/tracks/counter/frontend.ts
@@ -193,6 +193,15 @@ class CounterTrack extends Track<Config, Data> {
           Math.round(((value - yMin) / yRange) * RECT_HEIGHT);
     };
 
+    // For some reason the first entry in the counter track has lastValues[0] =
+    // 0. This will trigger a later assert if minValues[0] == maxValues[0] but
+    // not minValues[0] == lastValues[0] or it will lead to a track where the
+    // first segment is at y = 0. However if this check can be avoided, that would
+    // be preferred.
+    if (lastValues.length > 0 && lastValues[0] != minValues[0]) {
+      lastValues[0] = minValues[0];
+    }
+
     ctx.beginPath();
     ctx.moveTo(calculateX(data.timestamps[0]), zeroY);
     let lastDrawnY = zeroY;


### PR DESCRIPTION
When I tried to add a counter track to the trace files, I end up failing an assert when Perfetto tries to open them. And even if the assert was gone, it would graph the first segment at y = 0 incorrectly. This is because it checks if `minY == maxY`, then `assert(minY == lastY)`. However this always fails because `lastValues[0] == 0`. I cannot figure out exactly where this is set whether in the ocaml tracing library or in Perfetto itself. However this is a fix that does allow it to work as expected and could be removed if no longer needed later on.