### PR TITLE
Fix CORS error

### DIFF
--- a/src/trace_processor/rpc/httpd.cc
+++ b/src/trace_processor/rpc/httpd.cc
@@ -45,6 +45,7 @@ const char* kAllowedCORSOrigins[] = {
     "https://ui.perfetto.dev",
     "http://localhost:10000",
     "http://127.0.0.1:10000",
+    "https://magic-trace.org",
 };
 
 class Httpd : public base::HttpRequestHandler {


### PR DESCRIPTION
- Add https://magic-trace.org to kAllowedCORSOrigins[] in httpd.cc to resolve CORS error when opening magic-trace.org after running trace_processor
- background: CORS error prevented the pop up for uploading processed files from displaying because https://magic-trace.org was not given permission to be accessed while RPC server is running