### PR TITLE
Render events correctly for overlapped events, under a special case in GPU kernels.

### DIFF
--- a/src/trace_processor/importers/common/slice_tracker.cc
+++ b/src/trace_processor/importers/common/slice_tracker.cc
@@ -456,10 +456,13 @@ bool SliceTracker::MaybeCloseStack(int64_t new_ts,
     //          [     slice 2     ]
     // This is invalid stacking by the producer and should be fixed. Duration
     // events should either be nested or disjoint, never partially intersecting.
+    //
+    // Note: we intentionally do not drop the slice. For GPU events with
+    // programmatic dependent launch, partially overlapping events are
+    // legitimate, so we keep it.
     if (new_ts < end_ts && new_ts + new_dur > end_ts) {
       context_->storage->IncrementStats(
           stats::slice_drop_overlapping_complete_event);
-      return false;
     }
   }
   return true;


### PR DESCRIPTION
Hi @Svetlitski, thanks for maintaining magic-trace, it's a really helpful tool! My main use case of magic-trace is that it previously avoided a "bug" that Chrome Perfetto encountered. 

When there is overlap in events (in our case, GPU kernels), Perfetto would delete these events, in a commit sometime last year (https://github.com/google/perfetto/pull/1656). Actually, these are correct from the perspective of the GPU timing and are still serial, as one event is launched before the end of the preceding one. (for more reference, you can read https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/programmatic-dependent-launch.html if you are interested). And when this fork was rebased sometime in May, it's dragged in this issue again.

I just ran magic-trace locally, and confirmed the fix of the early behaviour.

Before (the kernels will disappear, which is not correct):
<img width="1052" height="222" alt="Screenshot 2026-06-03 at 7 42 15 PM" src="https://github.com/user-attachments/assets/5816f556-2820-4dde-a9d2-30e56e98bd23" />

After:
<img width="1682" height="425" alt="Screenshot 2026-06-03 at 7 40 12 PM" src="https://github.com/user-attachments/assets/19a4269f-baa7-4a5c-ba77-29a927bacaef" />


(Thus, I was wondering if you could either merge this in the current Perfetto submodule in magic-trace or maybe the release branch). Thanks a lot!